### PR TITLE
Require event-stream version after the issue with flatmap-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^2.4.1",
     "requirejs": "^2.1.11",
     "glob": "^3.2.9",
-    "event-stream": "^3.1.0",
+    "event-stream": "3.3.4",
     "csso": "^1.3.11",
     "gulp-util": "^2.2.16"
   },


### PR DESCRIPTION
https://github.com/dominictarr/event-stream/issues/116

This will ensure users of this package will pull in a safe version of event-stream